### PR TITLE
Fix centerlineLength function by updating previous_pair, add tests for this and riverWidthFromCenterline

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ river_object.plotCenterlineWidth(apply_smoothing=True, remove_intersections=True
 
 ### Return Width of River
 
-Return the width of the river at each (evenly spaced or smoothed) centerline coordinates as `(Longitude, Latitude) : width` in meters
+Return the width of the river at each (evenly spaced or smoothed) centerline coordinates as `(Longitude, Latitude) : width` in kilometers
 
 ```
 riverWidthFromCenterline(transect_span_distance=3,

--- a/centerline_width/centerline.py
+++ b/centerline_width/centerline.py
@@ -242,7 +242,7 @@ def riverWidthFromCenterlineCoordinates(river_object=None,
 		return points_intersect_false_edges
 
 	# Generate a list of lines from the centerline point with its normal
-	logger.info("[PROCESSING] Calculating and positioning width lines, may takes a few minutes...")
+	logger.info("[PROCESSING] Calculating and positioning width lines, may take a few minutes...")
 
 	min_x, min_y, max_x, max_y = river_object.bank_polygon.bounds
 	for centerline_point, slope in centerline_slope.items():
@@ -441,4 +441,6 @@ def centerlineLength(centerline_coordinates=None, ellipsoid="WGS84"):
 			lat1, lat2 = previous_pair[1], xy_pair[1]
 			_, _, distance_between_meters = geodesic.inv(lon1, lat1, lon2, lat2)
 			total_length += distance_between_meters
+		# Set previous_pair to xy_pair for the next iteration.
+		previous_pair = xy_pair
 	return total_length/1000

--- a/centerline_width/pytests/test_centerline.py
+++ b/centerline_width/pytests/test_centerline.py
@@ -90,3 +90,33 @@ def test_riverWidthFromCenterline_coordinateUnitInvalidTypes(invalid_input, erro
 	with pytest.raises(ValueError, match=re.escape("[coordinate_unit]: Must be a str, current type = '{0}'".format(error_output))):
 		centerline_width.riverWidthFromCenterline(river_object=river_class_example,
 										coordinate_unit=invalid_input)
+
+def test_riverCenterline_centerlineLength():
+	csv_example = StringIO()
+	csv_example.write("llat,llon,rlat,rlon\n")
+	csv_example.write("48.286399957085024,-4.259939230629442,48.28244110043403,-4.255739731090472\n")
+	csv_example.write("48.28500274859866,-4.2625639178417885,48.280578002893776,-4.2602891889242755\n")
+	csv_example.write("48.283954817150175,-4.265713542496371,48.28011221789134,-4.265888521643745\n")
+	csv_example.write("48.283954817150175,-4.26833822970741,48.28011221789134,-4.2711378960671595\n")
+	csv_example.write("48.28558492344624,-4.271312875214591,48.28244110043403,-4.276212291343171\n")
+	csv_example.write("48.287447838366376,-4.27393756242688,48.28581779152722,-4.278836978555489\n")
+	csv_example.seek(0)
+	test_river = centerline_width.riverCenterline(csv_data=csv_example)
+	assert test_river.centerlineLength == 1.3534252753118123
+
+def test_riverWidthFromCenterline():
+	csv_example = StringIO()
+	csv_example.write("llat,llon,rlat,rlon\n")
+	csv_example.write("48.286399957085024,-4.259939230629442,48.28244110043403,-4.255739731090472\n")
+	csv_example.write("48.28500274859866,-4.2625639178417885,48.280578002893776,-4.2602891889242755\n")
+	csv_example.write("48.283954817150175,-4.265713542496371,48.28011221789134,-4.265888521643745\n")
+	csv_example.write("48.283954817150175,-4.26833822970741,48.28011221789134,-4.2711378960671595\n")
+	csv_example.write("48.28558492344624,-4.271312875214591,48.28244110043403,-4.276212291343171\n")
+	csv_example.write("48.287447838366376,-4.27393756242688,48.28581779152722,-4.278836978555489\n")
+	csv_example.seek(0)
+	test_river = centerline_width.riverCenterline(csv_data=csv_example)
+	river_width_dict = test_river.riverWidthFromCenterline()
+	assert river_width_dict == {
+		(-4.271614588856146, 48.282642262514564): 0.5026142454914809,
+		(-4.2628112256127935, 48.282290840533314): 0.48351741792900327,
+	}


### PR DESCRIPTION
In the `centerlineLength` function we were never updating previous_pair, which meant we were calculating distances from the initial point rather than intermediate point.

Add tests for this and the `riverWidthFromCenterline` function.

Also some minor doc updates to the `README.md` file, one of which to clarify the return values of the `riverWidthFromCenterline` function.